### PR TITLE
Use form to refine prompt

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ def generate_image(tool_input, cat):
     The input is the user's requested image.
     """
 
-    settings = cat.mad_hatter.plugins["meow_art"].load_settings()
+    settings = cat.mad_hatter.get_plugin().load_settings()
 
     if settings == {}:
         log.error("No configuration found for MeowArt")

--- a/main.py
+++ b/main.py
@@ -1,80 +1,72 @@
-from cat.mad_hatter.decorators import tool, plugin
-from pydantic import BaseModel, Field, model_validator
-from cat.log import log
-from enum import Enum
 import requests
 import json
+from typing import Tuple
+from pydantic import BaseModel, Field, model_validator
 
-class ImageSize(Enum):
-    quad: str = '1024x1024'
-    width: str = '1792x1024'
-    height: str = '1024x1792'
-    medium: str = '512x512'
-    low: str = '256x256'
-
-class Quality(Enum):
-    hd: str = 'hd'
-    standard: str = 'standard'
-
-class Style(Enum):
-    natural: str = 'natural'
-    vivid: str = 'vivid'
-
-class Model(Enum):
-    dalle3: str = 'dall-e-3'
-    dalle2: str = 'dall-e-2'
-
-class Settings(BaseModel):
-    api_key: str = Field(title="API Key", description="The API key for OpenAI's image generation API.", default="")
-    image_size: ImageSize = Field(title="Image size", description="The size for the image to generate. For dall-e-3 you can choose between '1024x1024', '1792x1024' and '1024x1792' while for dall-e-2 you can choose between '1024x1024', '512x512' and '256x256'", default=ImageSize.quad)
-    quality: Quality = Field(title="Image quality", description="The quality for the image to generate. It will be used only with dall-e-3", default=Quality.hd)
-    style: Style = Field(title="Image style", description="The style for the image to generate. It will be used only with dall-e-3", default=Style.natural)
-    model: Model = Field(title="Model", description="The model to use for the image to generate", default=Model.dalle3)    
-    
-    @model_validator(mode='after')
-    def check_image_size_validator(self) -> 'Settings':
-        model = self.model
-        threshold = self.image_size
-        if  (threshold == ImageSize.width and model == Model.dalle2) or (threshold == ImageSize.height and model == Model.dalle2):
-            raise ValueError("Image size not acepted for this model, please select a '1024x1024' or less")
-        if  (threshold == ImageSize.medium and model == Model.dalle3) or (threshold == ImageSize.low and model == Model.dalle3):
-            raise ValueError("Image size not acepted for this model, please select a '1024x1024' or more")
-        return self
+from cat.log import log
+from cat.experimental.form import form, CatForm
 
 
-    
-@plugin
-def settings_model():
-    return Settings
+def generate_image_from_api(prompt: str, settings: dict) -> Tuple[str, Tuple[int, int]]:
 
-@tool(return_direct=True)
-def generate_image(tool_input, cat):
-    """
-    Useful to generate an image based on a text.
-    The input is the user's requested image.
-    """
-
-    settings = cat.mad_hatter.get_plugin().load_settings()
-
-    if settings == {}:
-        log.error("No configuration found for MeowArt")
-        return "You did not configure the API key for the image generation API!"
-
-    req = requests.post("https://api.openai.com/v1/images/generations", 
-                        headers={
-                            "Authorization": f"Bearer {settings['api_key']}",
-                            "Content-Type": "application/json"
-                        }, data=json.dumps({
-                            "quality": settings['quality'],
-                            "model": settings['model'],
-                            "prompt": tool_input,
-                            "style": settings['style'],
-                            "size": settings['image_size']
-                        }))
+    headers = {
+        "Authorization": f"Bearer {settings['api_key']}",
+        "Content-Type": "application/json"
+    }
+    data = json.dumps({
+        "quality": settings['quality'],
+        "model": settings['model'],
+        "prompt": prompt,
+        "style": settings['style'],
+        "size": settings['image_size']
+    })
+    req = requests.post(
+        "https://api.openai.com/v1/images/generations", 
+        headers=headers,
+        data=data
+    )
     res = req.json()
 
-    image = res['data'][0]['url']
-
+    image_url = res['data'][0]['url']
     size = settings['image_size'].split('x')
-    # TODO: It would be nice to add a button to download the original quality of the image
-    return f"<img src='{image}' style='width: {int(size[0]) / 2}px; height: {int(size[1]) / 2}px;' alt='Generated image' />"
+    size[0] = int(size[0])
+    size[1] = int(size[1])
+
+    return image_url, size
+
+
+
+# data structure to fill up
+class ImageGenerationPrompt(BaseModel):
+    image_prompt: str
+
+# forms let you control goal oriented conversations
+@form
+class ImageGenerationForm(CatForm):
+    description = "Generate image"
+    model_class = ImageGenerationPrompt
+    start_examples = [
+        "generate image",
+        "create picture"
+    ]
+    stop_examples = [
+        "stop image generation",
+        "exit image",
+        "don't want to create image"
+    ]
+    ask_confirm = True
+
+    def submit(self, form_data):
+        
+        settings = self.cat.mad_hatter.get_plugin().load_settings()
+        if settings == {}:
+            log.error("No configuration found for MeowArt")
+            return "You did not configure the API key for the image generation API!"
+        
+        prompt = form_data["image_prompt"]
+        image, size = generate_image_from_api(prompt, settings)
+ 
+        # TODO: It would be nice to add a button to download the original quality of the image
+        return {
+            "output": f"<img src='{image}' style='width: {int(size[0]) / 2}px; height: {int(size[1]) / 2}px;' alt='Generated image' />"
+        }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "Meow Art",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "A plugin to generate images from a prompt. It's suggested to start the prompt with 'generate an image that ...'",
     "author_name": "zAlweNy26",
     "author_url": "https://github.com/zAlweNy26",

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,46 @@
+from enum import Enum
+from pydantic import BaseModel, Field, model_validator
+
+from cat.log import log
+from cat.mad_hatter.decorators import plugin
+
+class ImageSize(Enum):
+    quad: str = '1024x1024'
+    width: str = '1792x1024'
+    height: str = '1024x1792'
+    medium: str = '512x512'
+    low: str = '256x256'
+
+class Quality(Enum):
+    hd: str = 'hd'
+    standard: str = 'standard'
+
+class Style(Enum):
+    natural: str = 'natural'
+    vivid: str = 'vivid'
+
+class Model(Enum):
+    dalle3: str = 'dall-e-3'
+    dalle2: str = 'dall-e-2'
+
+class Settings(BaseModel):
+    api_key: str = Field(title="API Key", description="The API key for OpenAI's image generation API.", default="")
+    image_size: ImageSize = Field(title="Image size", description="The size for the image to generate. For dall-e-3 you can choose between '1024x1024', '1792x1024' and '1024x1792' while for dall-e-2 you can choose between '1024x1024', '512x512' and '256x256'", default=ImageSize.quad)
+    quality: Quality = Field(title="Image quality", description="The quality for the image to generate. It will be used only with dall-e-3", default=Quality.hd)
+    style: Style = Field(title="Image style", description="The style for the image to generate. It will be used only with dall-e-3", default=Style.natural)
+    model: Model = Field(title="Model", description="The model to use for the image to generate", default=Model.dalle3)    
+    
+    @model_validator(mode='after')
+    def check_image_size_validator(self) -> 'Settings':
+        model = self.model
+        threshold = self.image_size
+        if  (threshold == ImageSize.width and model == Model.dalle2) or (threshold == ImageSize.height and model == Model.dalle2):
+            raise ValueError("Image size not acepted for this model, please select a '1024x1024' or less")
+        if  (threshold == ImageSize.medium and model == Model.dalle3) or (threshold == ImageSize.low and model == Model.dalle3):
+            raise ValueError("Image size not acepted for this model, please select a '1024x1024' or more")
+        return self
+
+
+@plugin
+def settings_model():
+    return Settings


### PR DESCRIPTION
Since:
- when the prompt is long, the tool gets not triggered (embedding dissimilar from tool description)
- there is no possibility to refine the prompt before launching the API call

There is now a form allowing user to refine the prompt.
Also updated settings api 